### PR TITLE
Migrate to V0.8

### DIFF
--- a/config/groups/all_emails.json
+++ b/config/groups/all_emails.json
@@ -7,9 +7,7 @@
   "rules": [
     {
       "propertyId": "email",
-      "operation": {
-        "op": "exists"
-      }
+      "op": "exists"
     }
   ]
 }

--- a/config/groups/high_value_spanish_speakers.json
+++ b/config/groups/high_value_spanish_speakers.json
@@ -7,16 +7,12 @@
   "rules": [
     {
       "propertyId": "ltv",
-      "operation": {
-        "op": "gt"
-      },
+      "op": "gt",
       "match": "100"
     },
     {
       "propertyId": "language",
-      "operation": {
-        "op": "eq"
-      },
+      "op": "eq",
       "match": "Spanish"
     }
   ]

--- a/config/properties/ltv.json
+++ b/config/properties/ltv.json
@@ -14,7 +14,7 @@
   "filters": [
     {
       "key": "state",
-      "op": "equals",
+      "op": "eq",
       "match": "successful"
     }
   ]

--- a/config/properties/purchase_count.json
+++ b/config/properties/purchase_count.json
@@ -14,7 +14,7 @@
   "filters": [
     {
       "key": "state",
-      "op": "equals",
+      "op": "eq",
       "match": "successful"
     }
   ]

--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
     "node": ">=12.0.0 <17.0.0"
   },
   "dependencies": {
-    "@grouparoo/core": "0.7.8",
-    "@grouparoo/mailchimp": "0.7.8",
-    "@grouparoo/sqlite": "0.7.8",
-    "@grouparoo/ui-community": "0.7.8"
+    "@grouparoo/core": "0.8.0",
+    "@grouparoo/mailchimp": "0.8.0",
+    "@grouparoo/sqlite": "0.8.0",
+    "@grouparoo/ui-community": "0.8.0"
   },
   "devDependencies": {
-    "@grouparoo/spec-helper": "0.7.8",
-    "@grouparoo/ui-config": "0.7.8",
+    "@grouparoo/spec-helper": "0.8.0",
+    "@grouparoo/ui-config": "0.8.0",
     "csv-parse": "4.16.3",
     "jest": "27.4.5",
     "sqlite3": "5.0.2"


### PR DESCRIPTION
**Merge after 0.8.0 release**

Referenced in [0.8.0 upgrade guide](https://www.grouparoo.com/docs/support/upgrading-grouparoo/v07-v08).

Migrating our App Example Config to V0.8.0.

